### PR TITLE
Index service integration tests

### DIFF
--- a/src/main/java/org/testeditor/web/xtext/index/resources/IGlobalScopeResource.xtend
+++ b/src/main/java/org/testeditor/web/xtext/index/resources/IGlobalScopeResource.xtend
@@ -31,7 +31,13 @@ interface IGlobalScopeResource {
 	 *   }
 	 * 
 	 * @param context The complete content of the resource (file) from where the
-	 * scope is looked at. Transmitted as plain-text in the body of the request.
+	 * scope is looked at. Optional. Transmitted as plain-text in the body of the request.
+	 * @param contentType The content type of the context resource. This is optional
+	 * if the content type can be determined from the context URI (file extension).
+	 * Transmitted as query parameter "contentType".
+	 * @param contextURI The URI of the context resource. This must be a valid URI name, but
+	 * not necessarily a resolvable locator. The file extension should match the resource's
+	 * content type, if applicable. Transmitted as query parameter "contextURI".
 	 * @param eReferenceURIString The URI of the EReference for which all
 	 * potential targets in the scope are to be retrieved. Transmitted as query
 	 * parameter "reference".

--- a/src/test/java/org/testeditor/web/xtext/index/resources/GlobalScopeResourceIntegrationTest.xtend
+++ b/src/test/java/org/testeditor/web/xtext/index/resources/GlobalScopeResourceIntegrationTest.xtend
@@ -1,28 +1,31 @@
 package org.testeditor.web.xtext.index.resources
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.module.SimpleModule
 import java.io.InputStream
 import java.util.List
-import javax.ws.rs.client.Entity
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtext.XtextPackage
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.junit.Test
 import org.testeditor.tcl.TclPackage
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionDeserializer
+import org.testeditor.web.xtext.index.resources.bitbucket.AbstractIntegrationTest
 
-import static javax.ws.rs.core.Response.Status.OK
+import static javax.ws.rs.core.Response.Status.*
 import static org.assertj.core.api.Assertions.assertThat
 
-class GlobalScopeResourceIntegrationTest extends org.testeditor.web.xtext.index.resources.bitbucket.AbstractIntegrationTest {
+class GlobalScopeResourceIntegrationTest extends AbstractIntegrationTest {
 
-	@Test
-	def void macroReferencedByTcl() {
-		// given
-		addFileToIndex(
-			"pack/MacroLib.tml",
-			'''
+	val LARGE_INDEX_SIZE = 100
+	val MACRO_COLLECTION_REF_CONTEXT = '''
+			package pack
+			
+			# Context
+			
+			* Some Teststep
+			Macro: 
+		'''
+	val DEFAULT_FILE_URI_IN_INDEX = "pack/MacroLib.tml"
+	val DEFAULT_FILE_IN_INDEX = '''
 				package pack
 				
 				# MacroLib
@@ -34,30 +37,50 @@ class GlobalScopeResourceIntegrationTest extends org.testeditor.web.xtext.index.
 					Component: SomeComponent
 					- Some fixture call
 			'''
-		)
 
-		val context = '''
-			package pack
-			
-			# Context
-			
-			* Some Teststep
-			Macro: 
-		'''
+	@Test
+	def void macroReferencedByTcl() {
+		// given
+		addFileToIndex(DEFAULT_FILE_URI_IN_INDEX, DEFAULT_FILE_IN_INDEX)
+
+		val context = MACRO_COLLECTION_REF_CONTEXT
 
 		val macroCollectionReference = EcoreUtil.getURI(TclPackage.eINSTANCE.macroTestStepContext_MacroCollection).
 			toString
-		val client = dropwizardRule.client // new JerseyClientBuilder(dropwizardRule.environment).build("test client")
-		val jacksonModule = new SimpleModule
-		jacksonModule.addDeserializer(IEObjectDescription, new EObjectDescriptionDeserializer)
-		val objectMapper = dropwizardRule.environment.objectMapper.registerModule(jacksonModule)
-
+		
 		// when
-		val response = client.target('''http://localhost:«dropwizardRule.localPort»/xtext/index/global-scope''') //
-		.queryParam("reference", macroCollectionReference) //
-		.queryParam("contentType", 'tcl') //
-		.queryParam("contextURI", 'pack/context.tcl') //
-		.request.authHeader.post(Entity.text(context))
+		val response = postGlobalScopeRequest(context, macroCollectionReference,'tcl', 'pack/context.tcl')
+
+		val payload = objectMapper.<List<IEObjectDescription>>readValue(response.entity as InputStream,
+			new TypeReference<List<IEObjectDescription>>() {
+			})
+
+		// then
+		assertThat(response.status).isEqualTo(OK.statusCode)
+		assertThat(payload).satisfies [
+			assertThat(it).isInstanceOf(List)
+			assertThat(size).isEqualTo(1)
+			assertThat(head.getEClass.name).isEqualTo("MacroCollection")
+			assertThat(head.qualifiedName.toString).isEqualTo("MacroLib")
+		]
+
+	}
+	
+	/**
+	 * The index does not actually require the context resource's content!
+	 */
+	@Test
+	def void macroReferencedByTclWithoutContextContent() {
+		// given
+		addFileToIndex(DEFAULT_FILE_URI_IN_INDEX, DEFAULT_FILE_IN_INDEX)
+
+		val context = null
+
+		val macroCollectionReference = EcoreUtil.getURI(TclPackage.eINSTANCE.macroTestStepContext_MacroCollection).
+			toString
+		
+		// when
+		val response = postGlobalScopeRequest(context, macroCollectionReference,'tcl', 'pack/context.tcl')
 
 		val payload = objectMapper.<List<IEObjectDescription>>readValue(response.entity as InputStream,
 			new TypeReference<List<IEObjectDescription>>() {
@@ -75,33 +98,96 @@ class GlobalScopeResourceIntegrationTest extends org.testeditor.web.xtext.index.
 	}
 
 	@Test
+	def void macroReferencedByTclOnLargeIndex() {
+		// given
+		indexOfSize(LARGE_INDEX_SIZE)
+
+		val context = MACRO_COLLECTION_REF_CONTEXT
+
+		val macroCollectionReference = EcoreUtil.getURI(TclPackage.eINSTANCE.macroTestStepContext_MacroCollection).
+			toString
+
+		// when
+		val response = postGlobalScopeRequest(context, macroCollectionReference,'tcl', 'pack/context.tcl')
+
+		val payload = objectMapper.<List<IEObjectDescription>>readValue(response.entity as InputStream,
+			new TypeReference<List<IEObjectDescription>>() {
+			})
+
+		// then
+		assertThat(response.status).isEqualTo(OK.statusCode)
+		assertThat(payload).satisfies [
+			assertThat(it).isInstanceOf(List)
+			assertThat(size).isEqualTo(LARGE_INDEX_SIZE)
+			assertThat(head.getEClass.name).isEqualTo("MacroCollection")
+			assertThat(head.qualifiedName.toString).isEqualTo("MacroLib0")
+			assertThat(last.qualifiedName.toString).isEqualTo("MacroLib" + (LARGE_INDEX_SIZE - 1))
+		]
+
+	}
+
+	@Test
 	def void noResourceNoContentCompletion() {
 		// given
-		val client = dropwizardRule.client
 		val reference = EcoreUtil.getURI(XtextPackage.eINSTANCE.grammar_UsedGrammars).toString
 		val contentType = "tsl"
 		val contextURI = "example.tsl"
-		val context = '''
-			package some
-			
-			# example
-			
-			* some "value" isa wrong .
-			* test .
-			* s "value""value""value".
-		'''
+		val context = MACRO_COLLECTION_REF_CONTEXT
 
 		// when
-		val response = client //
-		.target('''http://localhost:«dropwizardRule.localPort»/xtext/index/global-scope''') //
-		.queryParam("reference", reference) //
-		.queryParam("contentType", contentType) //
-		.queryParam("contextURI", contextURI) //
-		.request //
-		.authHeader //
-		.post(Entity.text(context))
+		val response = postGlobalScopeRequest(context, reference,contentType, contextURI)
 
 		// then
 		assertThat(response.status).isEqualTo(OK.statusCode)
 	}
+
+	@Test
+	def void noContentTypeFallsBackToFileExtension() {
+		// given
+		val reference = EcoreUtil.getURI(XtextPackage.eINSTANCE.grammar_UsedGrammars).toString
+		val contentType = null
+		val contextURI = "example.tsl"
+		val context = MACRO_COLLECTION_REF_CONTEXT
+
+		// when
+		val response = postGlobalScopeRequest(context, reference,contentType, contextURI)
+
+		// then
+		assertThat(response.status).isEqualTo(OK.statusCode)
+	}
+
+	@Test
+	def void nullContextURICausesError() {
+		// given
+		val reference = EcoreUtil.getURI(XtextPackage.eINSTANCE.grammar_UsedGrammars).toString
+		val contentType = null
+		val contextURI = null
+		val context = MACRO_COLLECTION_REF_CONTEXT
+
+		// when
+		val response = postGlobalScopeRequest(context, reference,contentType, contextURI)
+
+		// then
+		assertThat(response.status).isEqualTo(INTERNAL_SERVER_ERROR.statusCode)
+		assertThat((response.entity as InputStream).deserializeException.message).isEqualTo(
+			"No context URI was provided (URI is null).")
+	}
+	
+	@Test
+	def void emptyContextURICausesError() {
+		// given
+		val reference = EcoreUtil.getURI(XtextPackage.eINSTANCE.grammar_UsedGrammars).toString
+		val contentType = "tsl"
+		val contextURI = ""
+		val context = MACRO_COLLECTION_REF_CONTEXT
+
+		// when
+		val response = postGlobalScopeRequest(context, reference,contentType, contextURI)
+
+		// then
+		assertThat(response.status).isEqualTo(INTERNAL_SERVER_ERROR.statusCode)
+		assertThat((response.entity as InputStream).deserializeException.message).isEqualTo(
+			"Failed to create resource for URI '' of type 'tsl'.")
+	}
+
 }

--- a/src/test/java/org/testeditor/web/xtext/index/resources/bitbucket/AbstractIntegrationTest.xtend
+++ b/src/test/java/org/testeditor/web/xtext/index/resources/bitbucket/AbstractIntegrationTest.xtend
@@ -2,16 +2,25 @@ package org.testeditor.web.xtext.index.resources.bitbucket
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.google.inject.Guice
 import com.google.inject.util.Modules
 import io.dropwizard.testing.ResourceHelpers
 import io.dropwizard.testing.junit.DropwizardAppRule
 import java.io.File
+import java.io.InputStream
+import java.util.List
+import javax.ws.rs.client.Entity
 import javax.ws.rs.client.Invocation
+import javax.ws.rs.core.Response
 import org.eclipse.emf.common.util.URI
 import org.eclipse.jgit.junit.JGitTestUtil
+import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.scoping.IGlobalScopeProvider
 import org.junit.After
+import org.junit.Before
 import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -22,27 +31,18 @@ import org.testeditor.tsl.dsl.web.TslWebSetup
 import org.testeditor.web.xtext.index.XtextIndex
 import org.testeditor.web.xtext.index.XtextIndexApplication
 import org.testeditor.web.xtext.index.XtextIndexModule
+import org.testeditor.web.xtext.index.serialization.EObjectDescriptionDeserializer
 
 import static io.dropwizard.testing.ConfigOverride.config
-import org.junit.Before
-import com.fasterxml.jackson.databind.module.SimpleModule
-import org.eclipse.xtext.resource.IEObjectDescription
-import org.testeditor.web.xtext.index.serialization.EObjectDescriptionDeserializer
-import com.fasterxml.jackson.databind.ObjectMapper
-import java.util.List
-import java.io.InputStream
-import com.fasterxml.jackson.core.type.TypeReference
-import javax.ws.rs.client.Entity
 
 class AbstractIntegrationTest {
 
 	public static class TestXtextIndexApplication extends XtextIndexApplication {
-		val tslWebSetup = new TslWebSetup
 		val injector = Guice.createInjector(Modules.override(new TslRuntimeModule).with(new XtextIndexModule))
 		val index = injector.getInstance(XtextIndex) // construct index with language injector
 
 		override getLanguageSetups() {
-			return #[tslWebSetup, new TclStandaloneSetup, new AmlStandaloneSetup]
+			return #[new TslWebSetup, new TclStandaloneSetup, new AmlStandaloneSetup]
 		}
 
 		override public getIndexInstance() {
@@ -80,9 +80,9 @@ class AbstractIntegrationTest {
 		(dropwizardRule.application as TestXtextIndexApplication).indexInstance.add(
 			URI.createFileURI(file.absolutePath))
 	}
-	
-	def indexOfSize(int size) {
-		for (var counter = 0; counter < size; counter++) {
+
+	def addSeparateMacroCollectionToIndexTimes(int size) {
+		for (counter : 0 ..< size) {
 			addFileToIndex(
 				'''pack/MacroLib«counter».tml''',
 				'''
@@ -92,7 +92,7 @@ class AbstractIntegrationTest {
 					
 					## Macro«counter»
 					
-						template = "code"
+						template = "code«counter»"
 					
 						Component: SomeComponent
 						- Some fixture call
@@ -103,7 +103,7 @@ class AbstractIntegrationTest {
 
 	@After
 	public def void cleanupTempFolder() {
-		// since temporary folder is a class rule (to make sure it is run before the dropwizard rul),
+		// since temporary folder is a class rule (to make sure it is run before the dropwizard rule),
 		// cleanup all contents of the temp folder without deleting it itself
 		recursiveDelete(temporaryFolder.root, false)
 	}
@@ -128,9 +128,11 @@ class AbstractIntegrationTest {
 			file.delete
 		}
 	}
-	
-	protected def postGlobalScopeRequest(String context, String reference, String contentType, String contextURI) {
-		dropwizardRule.client //
+
+	protected def Response postGlobalScopeRequest(String context, String reference, String contentType,
+		String contextURI) {
+
+		return dropwizardRule.client //
 		.target('''http://localhost:«dropwizardRule.localPort»/xtext/index/global-scope''') //
 		.queryParam("reference", reference) //
 		.queryParam("contentType", contentType) //
@@ -142,7 +144,8 @@ class AbstractIntegrationTest {
 
 	protected def List<IEObjectDescription> deserializeIEObjectDescriptions(InputStream payload) {
 		return objectMapper.<List<IEObjectDescription>>readValue(payload,
-			new TypeReference<List<IEObjectDescription>>() {})
+			new TypeReference<List<IEObjectDescription>>() {
+			})
 	}
 
 	protected def Exception deserializeException(InputStream payload) {


### PR DESCRIPTION
Refactored our global scope resource integration tests / moved more stuff into the abstract base class to make the individual test cases less redundant and more readable.
I then added a few additional test cases:
* I ran against an index with 10000 files, each with two exported objects. Works.
* There's a test proving that the content of the context resource is not required, at least not under our current setup and test assumptions.

This PR is only to merge into the index-service-integration branch (which itself has become a bit messy 😕 ).